### PR TITLE
Dialog updates

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,7 @@
   "parser": "babel-eslint",
 
   "plugins": [
-    
+
   ],
 
   "rules": {
@@ -38,7 +38,7 @@
     "comma-spacing": [2, { "before": false, "after": true }],
     "comma-style": [2, "last"],
     "complexity": 0,
-    "consistent-return": 2,
+    "consistent-return": 1,
     "consistent-this": 0,
     "curly": [2, "multi-line"],
     "default-case": 0,
@@ -80,7 +80,6 @@
     "no-else-return": 2,
     "no-empty": 0,
     "no-empty-character-class": 2,
-    "no-empty-label": 2,
     "no-eq-null": 0,
     "no-eval": 2,
     "no-ex-assign": 2,
@@ -100,7 +99,7 @@
     "no-irregular-whitespace": 2,
     "no-iterator": 2,
     "no-label-var": 2,
-    "no-labels": 2,
+    "no-labels": 2, // disallow use of labeled statements
     "no-lone-blocks": 0,
     "no-lonely-if": 0,
     "no-loop-func": 0,
@@ -148,7 +147,6 @@
     "no-unreachable": 2,
     "no-unused-expressions": 0,
     "no-unused-vars": [2, { "vars": "all", "args": "none" }],
-    // "no-use-before-define": 2,
     "no-var": 0,
     "no-void": 0,
     "no-warning-comments": 0,
@@ -163,13 +161,12 @@
     "semi": [2, "always"],
     "semi-spacing": 0,
     "sort-vars": 0,
-    "space-after-keywords": [2, "always"],
+    "keyword-spacing": [2, { "before": false, "after": true }],
     "space-before-blocks": [2, "always"],
     "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}],
     "space-in-brackets": 0,
     "space-in-parens": [2, "never"],
     "space-infix-ops": 2,
-    "space-return-throw-case": 2,
     "space-unary-ops": [2, { "words": true, "nonwords": false }],
     "strict": 0,
     "use-isnan": 2,

--- a/demo/css/main.css
+++ b/demo/css/main.css
@@ -9,26 +9,30 @@ body {
 }
 
 .dialog-container,
-.dialog-background {
+.dialog-backdrop {
+    align-items: center;
+    display: flex;
+    justify-content: center;
     position: fixed;
     height: 100%;
     left: 0;
     overflow: hidden;
     top: 0;
     width: 100%;
-}
-
-.dialog-background {
-    background-color: rgba(0, 0, 0, 0.85);
     z-index: 100;
 }
 
 .dialog-container {
-    align-items: center;
-    display: flex;
-    justify-content: center;
+    background-color: green;
     pointer-events: none;
-    z-index: 101;
+}
+
+.dialog-container.no-backdrop {
+    background-color: transparent;
+}
+
+.dialog-backdrop {
+    z-index: 99;
 }
 
 .dialog {
@@ -36,7 +40,7 @@ body {
     box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.4);
     padding: 3em;
     pointer-events: auto;
-    position: relative; 
+    position: relative;
     width: 26em;
 }
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,11 +1,21 @@
+<!doctype html>
 <html>
 <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
     <title>Vanilla UI</title>
     <link rel="stylesheet" href="css/main.css">
 </head>
 <body>
-    <h1>Vanilla UI</h1>
+
+    <div class="main-content">
+        <h1>Vanilla UI—Dialog</h1>
+        <button class="js-dialog-btn" type="button">Open dialog 1</button>
+        <button class="js-dialog-btn-2" type="button">Open dialog 2</button>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
+    </div>
 
     <div class="dialog-container js-dialog">
         <div class="dialog">
@@ -23,11 +33,6 @@
             <button class="js-dialog-close-btn-2">You got me!</button>
         </div>
     </div>
-    
-    <button class="js-dialog-btn">Open dialog 1</button>
-    <button class="js-dialog-btn-2">Open dialog 2</button>
-
-    <div class="dialog-background js-dialog-backdrop"></div>
 
     <script src="../lib/vanilla-ui.js"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -10,16 +10,16 @@
   },
   "devDependencies": {
     "babel": "6.3.13",
-    "babel-core": "6.1.18",
-    "babel-eslint": "4.1.3",
-    "babel-loader": "6.1.0",
+    "babel-core": "^6.7.4",
+    "babel-eslint": "5.0.0",
+    "babel-loader": "^6.2.4",
     "babel-plugin-add-module-exports": "0.1.2",
     "babel-preset-es2015": "6.3.13",
     "chai": "3.4.1",
-    "eslint": "1.7.2",
-    "eslint-loader": "1.1.0",
+    "eslint": "2.2.0",
+    "eslint-loader": "^1.3.0",
     "mocha": "2.3.4",
-    "webpack": "1.12.9",
+    "webpack": "^1.12.14",
     "yargs": "3.32.0"
   },
   "repository": {
@@ -34,7 +34,7 @@
     "ui",
     "components"
   ],
-  "author": "Bard N. Hovde & David Berner",
+  "author": "Bard N. Hovde, David Berner & Chris Pearce",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/fedordead/vanilla-ui/issues"

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -1,59 +1,68 @@
 /**
  * @function UIDialog
  * @version 0.0.2
- * @desc display a Dialog
  */
 
 export default function UIDialog(userOptions) {
 
-    var DOM,
+    let DOM,
         state = {};
-        
+
     const defaults = {
         dialog:         '.js-dialog',
         openBtn:        '.js-dialog-btn',
         closeBtn:       '.js-dialog-close-btn',
-        backdrop:       '.js-dialog-backdrop',
         isModal:        false,
         showBackdrop:   true
     };
 
     // Combine defaults with passed in options
     const settings = Object.assign(defaults, userOptions);
-    
+
+    // Create the backdrop
+    const backdrop = document.createElement('div');
+
+    backdrop.classList.add('dialog-backdrop');
+
     init();
 
     /**
-    * @function init
-    * @desc Initialises the dialog
-    */ 
+     * @function init
+     * @desc Initialises the dialog
+     */
     function init() {
-        
+
         // Save all DOM queries for future use
         DOM = {
             'page': document.querySelectorAll('body')[0],
             'dialog': document.querySelectorAll(settings.dialog)[0],
             'openBtn': document.querySelectorAll(settings.openBtn)[0],
-            'closeBtn': document.querySelectorAll(settings.closeBtn)[0],
-            'backdrop': document.querySelectorAll(settings.backdrop)[0]
+            'closeBtn': document.querySelectorAll(settings.closeBtn)[0]
         };
-        
-        // Check if gallery exists, return if not
-        if (DOM.dialog === undefined) { return false; }
-        
+
+        // Check if the dialog exists, return if not
+        if (DOM.dialog === undefined) {
+            return false;
+        }
+
+        // Remove backdrop if turned off
+        if (!settings.showBackdrop) {
+            DOM.dialog.classList.add('no-backdrop');
+        }
+
         // Set page attribute
         DOM.page.setAttribute('data-ui-dialog', 'is-initialised');
 
         // Find dialog and hide if not already hidden
         DOM.dialog.classList.add('is-hidden');
-        DOM.backdrop.classList.add('is-hidden');
-        
-        // Attach event listeners to buttons
+
+        // Attach event listeners
         DOM.openBtn.addEventListener('click', show, false);
         DOM.closeBtn.addEventListener('click', hide, false);
-        DOM.backdrop.addEventListener('click', hide, false);
+        if (!settings.isModal) {
+            backdrop.addEventListener('click', hide, false);
+        }
         document.addEventListener('keydown', keyHandler, false);
-
     }
 
     /**
@@ -62,8 +71,9 @@ export default function UIDialog(userOptions) {
     function show() {
         state.isOpen = true;
         DOM.dialog.classList.remove('is-hidden');
-        DOM.backdrop.classList.remove('is-hidden');
         DOM.page.setAttribute('data-current-dialog', settings.dialog);
+        // Add the backdrop to the page
+        DOM.page.appendChild(backdrop);
     };
 
     /**
@@ -72,10 +82,11 @@ export default function UIDialog(userOptions) {
     function hide() {
         state.isOpen = false;
         DOM.dialog.classList.add('is-hidden');
-        DOM.backdrop.classList.add('is-hidden');
         DOM.page.removeAttribute('data-current-dialog');
+        // Remove the backdrop from the page
+        DOM.page.removeChild(backdrop);
     };
-    
+
     /**
      * @function keyHandler
      * @desc Checks to see if escape (key 27) has been pressed and dialog not modal

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -8,12 +8,12 @@ const expect = chai.expect;
 var document;
 
 describe('UIDialog', function () {
-    
+
     before(function () {
         document = {};
         dialog = new UIDialog();
     })
-    
+
     describe('upon activation', function () {
         it('should return false if no DOM element exists', () => {
             // expect(lib.name).to.be.equal('Library');

--- a/src/components/dialog/readme.md
+++ b/src/components/dialog/readme.md
@@ -1,23 +1,27 @@
-Vanilla UI - Dialog
+# Vanilla UI - Dialog
 
-A widget that...
+A widget that…
 
-Accessibility
+## Accessibility
 
-The component has been created in accordance with the WAI ARIA guidelines for modal dialogs which can be found here in full - https://www.w3.org/TR/wai-aria-practices/#modal_dialog
+The component has been created in accordance with the WAI ARIA guidelines for modal dialogs which can be found here in full: <https://www.w3.org/TR/wai-aria-practices/#modal_dialog>.
 
 In summary the following approach has been applied:
 
-...
+***
 
-TODO: 
+## TODO
 
-...
+* Add all ARIA.
+* Disable vertical scroll on the `<body>`?
+* Only 1 to be open at a time?
 
-CSS Fallbacks
+***
 
-...
+## CSS Fallbacks
 
-Users without Javascript
+***
 
-...
+## Users without Javascript
+
+***

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,11 @@ import UIDialog from './components/dialog/dialog';
 
 let dialog1 = UIDialog();
 let dialog2 = UIDialog({
-    dialog:     '.js-dialog-2',
-    openBtn:    '.js-dialog-btn-2',
-    closeBtn:   '.js-dialog-close-btn-2',
-    isModal:    true
+    dialog:         '.js-dialog-2',
+    openBtn:        '.js-dialog-btn-2',
+    closeBtn:       '.js-dialog-close-btn-2',
+    isModal:        true,
+    showBackdrop:   false
 });
 
 // Stop whining about unused variables


### PR DESCRIPTION
- Updating NPM packages including `eslint` which meant updating some of the linting rules.
- **Backdrop:**
  - Adding the functionality to remove the backdrop if the `showBackdrop` setting is `false`, handled simply by a CSS state hook which sets the `background-color` to `transparent`.
  - Changing the backdrop so it's not needing to be hardcoded into the document—instead add it via JS. I figured the less HTML the consumer has to worry about the better plus it felt nicer to only include the HTML that'll still work when JS is off.
  - Adding the functionality to disallow clicking anywhere outside of the dialog to close the dialog when `isModal` is `true` as the only thing that can close a **modal** dialog is a close button inside the dialog.

Next I'll probably look at the keyboard behaviour beyond the `ESC` key.
