### PR TITLE
Ui modal updates

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
   "presets": ["es2015"],
-  "plugins": ["babel-plugin-add-module-exports"]
+  "plugins": ["babel-plugin-add-module-exports",
+             "transform-object-rest-spread"]
 }

--- a/demo/css/main.css
+++ b/demo/css/main.css
@@ -8,42 +8,29 @@ body {
     font-family: sans-serif;
 }
 
-.dialog-container,
 .dialog-backdrop {
-    align-items: center;
-    display: flex;
-    justify-content: center;
-    position: fixed;
-    height: 100%;
+    background-color: rgba(0,0,0,0.5);
+    bottom: 0;
     left: 0;
     overflow: hidden;
+    position: fixed;
+    right: 0;
     top: 0;
-    width: 100%;
-    z-index: 100;
-}
-
-.dialog-container {
-    background-color: green;
-    pointer-events: none;
-}
-
-.dialog-container.no-backdrop {
-    background-color: transparent;
-}
-
-.dialog-backdrop {
-    z-index: 99;
+    z-index: 1;
 }
 
 .dialog {
     background-color: #fff;
     box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.4);
+    display: none;
+    left: calc(50vw - 13em);
     padding: 3em;
-    pointer-events: auto;
-    position: relative;
+    position: fixed;
+    top: 20vh;
     width: 26em;
+    z-index: 2;
 }
 
-.is-hidden {
-    display: none !important;
+.dialog.is-active {
+    display: block !important;
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,8 +9,8 @@
 
     <div class="main-content">
         <h1>Vanilla UI—Dialog</h1>
-        <button class="js-dialog-btn" type="button" aria-controls="my-dialog">Open dialog 1</button>
-        <button class="js-dialog-btn-2" type="button" aria-controls="another-dialog">Open dialog 2</button>
+        <button class="js-dialog-btn-open" type="button" data-controls-modal="my-dialog">Open dialog 1</button>
+        <button class="js-dialog-btn-open-2" type="button" data-controls-modal="another-dialog">Open dialog 2</button>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
@@ -23,7 +23,7 @@
         <button class="js-dialog-close-btn">Close dialog 1</button>
     </div>
 
-    <div id="another-dialog" class="dialog js-dialog-2">>
+    <div id="another-dialog" class="dialog js-dialog-2">
         <h3>Oops!</h3>
         <p>Deadly Neurotoxin gas released!</p>
         <p>PS: I'm a modal, so no escape for you!</p>

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,29 +9,25 @@
 
     <div class="main-content">
         <h1>Vanilla UI—Dialog</h1>
-        <button class="js-dialog-btn" type="button">Open dialog 1</button>
-        <button class="js-dialog-btn-2" type="button">Open dialog 2</button>
+        <button class="js-dialog-btn" type="button" aria-controls="my-dialog">Open dialog 1</button>
+        <button class="js-dialog-btn-2" type="button" aria-controls="another-dialog">Open dialog 2</button>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
     </div>
 
-    <div class="dialog-container js-dialog">
-        <div class="dialog">
-            <h3>Hello!</h3>
-            <p>I am dialog 1 content. I can be closed with both escape and buttons.</p>
-            <button class="js-dialog-close-btn">Close dialog 1</button>
-        </div>
+    <div id="my-dialog" class="dialog js-dialog">
+        <h3>Hello!</h3>
+        <p>I am dialog 1 content. I can be closed with both escape and buttons.</p>
+        <button class="js-dialog-close-btn">Close dialog 1</button>
     </div>
 
-    <div class="dialog-container js-dialog-2">
-        <div class="dialog">
-            <h3>Oops!</h3>
-            <p>Deadly Neurotoxin gas released!</p>
-            <p>PS: I'm a modal, so no escape for you!</p>
-            <button class="js-dialog-close-btn-2">You got me!</button>
-        </div>
+    <div id="another-dialog" class="dialog js-dialog-2">>
+        <h3>Oops!</h3>
+        <p>Deadly Neurotoxin gas released!</p>
+        <p>PS: I'm a modal, so no escape for you!</p>
+        <button class="js-dialog-close-btn-2">You got me!</button>
     </div>
 
     <script src="../lib/vanilla-ui.js"></script>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "babel": "6.3.13",
     "babel-core": "^6.7.4",
     "babel-eslint": "5.0.0",
+    "babel-plugin-transform-object-rest-spread": "6.8.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-add-module-exports": "0.1.2",
     "babel-preset-es2015": "6.3.13",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vanilla-ui",
   "version": "0.0.1",
   "description": "UI Components written in ES6. Nothing artificial, all organic!",
-  "main": "lib/library.js",
+  "main": "lib/vanilla-ui.js",
   "scripts": {
     "build": "webpack --mode=build",
     "dev": "webpack --progress --colors --watch --mode=dev",

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -1,28 +1,236 @@
+import {keyCodes, defaultClassNames, focusableSelectors} from '../../constants';
+import qa from '../../utils/qa';
+import defer from '../../utils/defer';
+
 /**
  * @function UIDialog
  * @version 0.0.2
+ * @desc Main UIDialog function. Creates instances of the dialog based on
+ * parameters passed in.
+ * @param {object} settings
  */
-
-import {keyCodes, defaultClassNames} from '../../constants';
-
-
 const UIDialog = ({
         dialog = '.js-dialog',
         openBtn = '.js-dialog-btn',
         closeBtn = '.js-dialog-close-btn',
         isModal = false,
+        isAlert = false,
+        readyClass = defaultClassNames.IS_READY,
+        activeClass = defaultClassNames.IS_ACTIVE,
         showBackdrop = true
     } = {}) => {
 
-    let DOM,
-        state = {};
+    // Stores all the dom nodes for the module
+    let DOM = {
+        dialogs: qa(dialog)
+    };
 
-    // Create the backdrop
-    const backdrop = document.createElement('div');
+    // Keeps track of current state
+    let state = {
+        currentOpenButton: null,
+        currentDialog: null,
+        focusableElements: null //  elements within modal
+    };
 
-    backdrop.classList.add(defaultClassNames.DIALOG_BACKDROP);
 
-    init();
+    /**
+     * @function createBackdrop
+     * @type private
+     * @desc Creates the dialog backdrop
+     */
+    function createBackdrop() {
+        // Create the backdrop
+        DOM.backdrop = document.createElement('div');
+
+        DOM.backdrop.classList.add(defaultClassNames.DIALOGBACKDROP);
+
+        addBackdropA11y(DOM.backdrop);
+    }
+
+
+    /**
+     * @function addDialogA11y
+     * @type private
+     * @desc Applies relevant roles and attributes to the dialog
+     * @param {node} dialog
+     */
+    function addDialogA11y(dialog) {
+        const role = isAlert ? 'alertdialog' : 'dialog';
+
+        dialog.setAttribute('aria-hidden', 'true');
+        dialog.setAttribute('role', role);
+    }
+
+
+    /**
+     * @function addBackdropA11y
+     * @type private
+     * @desc Applies relevant roles and attributes to the backdrop
+     * @param {node} backdrop
+     */
+    function addBackdropA11y(backdrop) {
+        backdrop.setAttribute('aria-hidden', true);
+    }
+
+    /**
+     * @function closeDialog
+     * @type private
+     * @desc sets up dialog ready to be hidden
+     * @param {node} dialog
+     */
+    function closeDialog() {
+        hideDialog(state.currentDialog);
+    }
+
+    /**
+     * @function hideDialog
+     * @type private
+     * @desc adds aria attributes and hides dialog
+     * @param {node} dialog
+     */
+    function hideDialog(dialog) {
+
+        //  show container and focus the dialog
+        dialog.setAttribute('aria-hidden', true);
+        dialog.removeAttribute('tabindex');
+
+        // TODO - Unbind events
+
+        //  remove active state hook class
+        dialog.classList.remove(activeClass);
+
+        //  return focus to button that opened the dialog and reset state
+        state.currentOpenButton.focus();
+        state.currentOpenButton = null;
+    }
+
+
+    /**
+     * @function openDialog
+     * @type private
+     * @desc sets up dialog and state ready to be shown
+     * @param {node} dialog
+     */
+    function openDialog(e) {
+        // get trigger button so focus can be returned to it later
+        const button = e.target;
+        // get dialog that should be opened
+        const dialog = document.getElementById(button.getAttribute('aria-controls'));
+
+        //  update State
+        state.currentOpenButton = button;
+        state.currentDialog = dialog;
+
+        showDialog(dialog);
+    }
+
+
+    /**
+     * @function bindOpenEvents
+     * @type private
+     * @desc Finds all open buttons and attaches click event listener
+     * @param {node} dialog
+     */
+    function bindOpenEvents(dialog) {
+        const id = dialog.getAttribute('id');
+
+        // Grab all buttons which open this instance of the modal
+        let openButtons = qa(`${openBtn}[aria-controls="${id}"]`);
+
+        openButtons.forEach(button => button.addEventListener('click', openDialog));
+    }
+
+
+    /**
+     * @function bindCloseEvents
+     * @type private
+     * @desc Finds all close buttons and attaches click event listener
+     * @param {node} dialog
+     */
+    function bindCloseEvents(dialog = state.currentDialog) {
+        // Grab all buttons which open this instance of the modal
+        let closeButtons = qa(closeBtn);
+
+        closeButtons.forEach(button => button.addEventListener('click', closeDialog));
+    }
+
+
+    /**
+     * @function bindKeyCodeEvents
+     * @type private
+     * @desc Adds event listener for keydown on the document
+     */
+    function bindKeyCodeEvents() {
+        document.addEventListener('keydown', handleKeyPress);
+    }
+
+    /**
+     * @function bindBackdropEvents
+     * @type private
+     * @desc Adds event listener for keydown on the document
+     */
+    function bindBackdropEvents() {
+        DOM.backdrop.addEventListener('click', handleBackdropClick);
+    }
+
+
+    /**
+     * @function showDialog
+     * @type private
+     * @desc Sets up focusable elements, close and key events and displays modal
+     */
+    function showDialog(dialog) {
+        //  Focus the modal and remove aria attributes
+        dialog.setAttribute('tabindex', 1);
+        dialog.setAttribute('aria-hidden', false);
+
+        //  set first/last focusable elements
+        state.focusableElements = qa(focusableSelectors.join(), dialog);
+
+        //  focus first element if exists, otherwise focus dialog element
+        if (state.focusableElements.length) {
+            state.focusableElements[0].focus();
+        } else {
+            dialog.focus();
+        }
+
+        //  Bind events
+        defer(bindKeyCodeEvents);
+        defer(bindCloseEvents);
+        if (!isModal && DOM.backdrop) defer(bindBackdropEvents);
+
+        // Add backdrop if needed
+        if (DOM.backdrop) {
+            DOM.page.appendChild(DOM.backdrop);
+        }
+
+        //  Add class to make dialog visible
+        dialog.classList.add(activeClass);
+    }
+
+    /**
+     * @function handleKeyPress
+     * @desc Checks to see if escape (key 27) has been pressed and dialog not modal
+     * @param {Event} e
+     */
+    function handleKeyPress(e) {
+        if (e.keyCode === keyCodes.ESCAPE && !isModal) {
+            hideDialog(state.currentDialog);
+        }
+    }
+
+
+    /**
+     * @function handleBackdropClick
+     * @desc If backdrop has been clicked, dismiss dialog
+     * @param {Event} e
+     */
+    function handleBackdropClick(e) {
+        if (e.target === DOM.backdrop) {
+            hideDialog(state.currentDialog);
+        }
+    }
+
 
     /**
      * @function init
@@ -30,78 +238,33 @@ const UIDialog = ({
      */
     function init() {
 
-        // Save all DOM queries for future use
-        DOM = {
-            'page':     document.querySelectorAll('body')[0],
-            'dialog':   document.querySelectorAll(dialog)[0],
-            'openBtn':  document.querySelectorAll(openBtn)[0],
-            'closeBtn': document.querySelectorAll(closeBtn)[0]
-        };
-
-        // Check if the dialog exists, return if not
-        if (DOM.dialog === undefined) {
+        // Check if any dialogs exist, return if not
+        if (DOM.dialogs === undefined) {
             return false;
         }
 
-        // Remove backdrop if turned off
-        if (!showBackdrop) {
-            DOM.dialog.classList.add(defaultClassNames.NO_BACKDROP);
+        // Add body element to the DOM object
+        DOM.page = qa('body')[0];
+
+        if (showBackdrop) {
+            createBackdrop();
         }
 
-        // Set page attribute
-        DOM.page.setAttribute('data-ui-dialog', 'is-initialised');
+        DOM.dialogs.forEach(dialog => {
+            // add accessibility to dialog
+            addDialogA11y(dialog);
 
-        // Find dialog and hide if not already hidden
-        DOM.dialog.classList.add(defaultClassNames.IS_HIDDEN);
+            // set up event listeners for opening dialog
+            bindOpenEvents(dialog);
 
-        // Attach event listeners
-        DOM.openBtn.addEventListener('click', show, false);
-        DOM.closeBtn.addEventListener('click', hide, false);
-        if (!isModal) {
-            backdrop.addEventListener('click', hide, false);
-        }
-        document.addEventListener('keydown', keyHandler, false);
+            // set ready class
+            dialog.classList.add(readyClass);
+        });
     }
 
-    /**
-     * @function show
-     */
-    function show() {
-        state.isOpen = true;
-        DOM.dialog.classList.remove(defaultClassNames.IS_HIDDEN);
-        DOM.page.setAttribute('data-current-dialog', dialog);
-        // Add the backdrop to the page
-        DOM.page.appendChild(backdrop);
-    };
-
-    /**
-     * @function hide
-     */
-    function hide() {
-        state.isOpen = false;
-        DOM.dialog.classList.add(defaultClassNames.IS_HIDDEN);
-        DOM.page.removeAttribute('data-current-dialog');
-        // Remove the backdrop from the page
-        DOM.page.removeChild(backdrop);
-    };
-
-    /**
-     * @function keyHandler
-     * @desc Checks to see if escape (key 27) has been pressed and dialog not modal
-     * @param {Event} e
-     */
-    function keyHandler(e) {
-        if ([keyCodes.ESCAPE].indexOf(e.which) > -1 && state.isOpen === true && !isModal) {
-            e.preventDefault();
-            hide();
-        }
-    }
-
-    // External API
-    return {
-        show,
-        hide
-    };
+    // Initialise UIDialog module
+    init();
 };
+
 
 export default UIDialog;

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -1,4 +1,4 @@
-import {keyCodes, defaultClassNames, focusableSelectors} from '../../constants';
+import {keyCodes, defaultClassNames, NATIVELY_FOCUSABLE_ELEMENTS} from '../../constants';
 
 import createEl from '../../utils/createEl';
 import defer from '../../utils/defer';
@@ -145,7 +145,7 @@ const UIDialog = ({
         dialog.setAttribute('aria-hidden', false);
 
         //  Set the first and last focusable elements
-        state.focusableElements = qa(focusableSelectors.join(), dialog);
+        state.focusableElements = qa(NATIVELY_FOCUSABLE_ELEMENTS.join(), dialog);
 
         //  focus first element if exists, otherwise focus dialog element
         if (state.focusableElements.length) {

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -35,6 +35,36 @@ const UIDialog = ({
 
 
     /**
+     * @function bindBackdropEvents
+     * @desc Adds event listener for clicking on backdrop
+     */
+    function bindBackdropEvents() {
+        DOM.backdrop.addEventListener('click', handleBackdropClick);
+    }
+
+
+    /**
+     * @function unbindBackdropEvents
+     * @desc Removes event listener for clicking on backdrop
+     */
+    function unbindBackdropEvents() {
+        DOM.backdrop.removeEventListener('click', handleBackdropClick);
+    }
+
+
+    /**
+     * @function handleBackdropClick
+     * @desc If backdrop has been clicked, dismiss dialog
+     * @param {Event} e
+     */
+    function handleBackdropClick(e) {
+        if (e.target === DOM.backdrop) {
+            hideDialog(state.currentDialog);
+        }
+    }
+
+
+    /**
      * @function createBackdrop
      * @desc Creates the dialog backdrop
      */
@@ -49,6 +79,16 @@ const UIDialog = ({
 
 
     /**
+     * @function addBackdropA11y
+     * @desc Applies relevant roles and attributes to the backdrop
+     * @param {node} backdrop
+     */
+    function addBackdropA11y(backdrop) {
+        backdrop.setAttribute('aria-hidden', true);
+    }
+
+
+    /**
      * @function addDialogA11y
      * @desc Applies relevant roles and attributes to the dialog
      * @param {node} dialog
@@ -58,75 +98,6 @@ const UIDialog = ({
 
         dialog.setAttribute('aria-hidden', 'true');
         dialog.setAttribute('role', role);
-    }
-
-
-    /**
-     * @function addBackdropA11y
-     * @desc Applies relevant roles and attributes to the backdrop
-     * @param {node} backdrop
-     */
-    function addBackdropA11y(backdrop) {
-        backdrop.setAttribute('aria-hidden', true);
-    }
-
-    /**
-     * @function closeDialog
-     * @desc sets up dialog ready to be hidden
-     * @param {node} dialog
-     */
-    function closeDialog() {
-        hideDialog(state.currentDialog);
-    }
-
-    /**
-     * @function hideDialog
-     * @desc adds aria attributes and hides dialog
-     * @param {node} dialog
-     */
-    function hideDialog(dialog) {
-
-        //  show container and focus the dialog
-        dialog.setAttribute('aria-hidden', true);
-        dialog.removeAttribute('tabindex');
-
-        // Unbind events
-        unbindKeyCodeEvents();
-        if (!isModal && DOM.backdrop) {
-            unbindBackdropEvents();
-        }
-
-        //  Remove active state hook class
-        dialog.classList.remove(activeClass);
-
-        // Remove backdrop if needed
-        if (DOM.backdrop) {
-            DOM.page.removeChild(DOM.backdrop);
-        }
-
-        //  Return focus to button that opened the dialog and reset state
-        state.currentOpenButton.focus();
-        state.currentOpenButton = null;
-        state.currentDialog = null;
-    }
-
-
-    /**
-     * @function openDialog
-     * @desc sets up dialog and state ready to be shown
-     * @param {node} dialog
-     */
-    function openDialog(e) {
-        // get trigger button so focus can be returned to it later
-        const button = e.target;
-        // get dialog that should be opened
-        const dialog = document.getElementById(button.getAttribute('aria-controls'));
-
-        //  update State
-        state.currentOpenButton = button;
-        state.currentDialog = dialog;
-
-        showDialog(dialog);
     }
 
 
@@ -146,49 +117,21 @@ const UIDialog = ({
 
 
     /**
-     * @function bindCloseEvents
-     * @desc Finds all close buttons and attaches click event listener
+     * @function openDialog
+     * @desc sets up dialog and state ready to be shown
      * @param {node} dialog
      */
-    function bindCloseEvents(dialog = state.currentDialog) {
-        // Grab all buttons which open this instance of the modal
-        let closeButtons = qa(closeBtn);
+    function openDialog(e) {
+        // Get trigger button so focus can be returned to it later
+        const button = e.target;
+        // Get dialog that should be opened
+        const dialog = document.getElementById(button.getAttribute('aria-controls'));
 
-        closeButtons.forEach(button => button.addEventListener('click', closeDialog));
-    }
+        //  Update State
+        state.currentOpenButton = button;
+        state.currentDialog = dialog;
 
-
-    /**
-     * @function bindKeyCodeEvents
-     * @desc Adds event listener for keydown on the document
-     */
-    function bindKeyCodeEvents() {
-        document.addEventListener('keydown', handleKeyPress);
-    }
-
-    /**
-     * @function unbindKeyCodeEvents
-     * @desc Removes event listener for keydown on the document
-     */
-    function unbindKeyCodeEvents() {
-        document.removeEventListener('keydown', handleKeyPress);
-    }
-
-    /**
-     * @function bindBackdropEvents
-     * @desc Adds event listener for keydown on the document
-     */
-    function bindBackdropEvents() {
-        DOM.backdrop.addEventListener('click', handleBackdropClick);
-    }
-
-
-    /**
-     * @function unbindBackdropEvents
-     * @desc Removes event listener for keydown on the document
-     */
-    function unbindBackdropEvents() {
-        DOM.backdrop.removeEventListener('click', handleBackdropClick);
+        showDialog(dialog);
     }
 
 
@@ -201,7 +144,7 @@ const UIDialog = ({
         dialog.setAttribute('tabindex', 1);
         dialog.setAttribute('aria-hidden', false);
 
-        //  set first/last focusable elements
+        //  Set the first and last focusable elements
         state.focusableElements = qa(focusableSelectors.join(), dialog);
 
         //  focus first element if exists, otherwise focus dialog element
@@ -227,6 +170,79 @@ const UIDialog = ({
         dialog.classList.add(activeClass);
     }
 
+
+    /**
+     * @function bindCloseEvents
+     * @desc Finds all close buttons and attaches click event listener
+     * @param {node} dialog
+     */
+    function bindCloseEvents(dialog = state.currentDialog) {
+        // Grab all buttons which open this instance of the modal
+        let closeButtons = qa(closeBtn);
+
+        closeButtons.forEach(button => button.addEventListener('click', closeDialog));
+    }
+
+
+    /**
+     * @function closeDialog
+     * @desc Sets up dialog ready to be hidden
+     */
+    function closeDialog() {
+        hideDialog(state.currentDialog);
+    }
+
+
+    /**
+     * @function hideDialog
+     * @desc adds aria attributes and hides dialog, removing backdrop if needed
+     * @param {node} dialog
+     */
+    function hideDialog(dialog) {
+
+        //  show container and focus the dialog
+        dialog.setAttribute('aria-hidden', true);
+        dialog.removeAttribute('tabindex');
+
+        // Unbind events
+        unbindKeyCodeEvents();
+        if (!isModal && DOM.backdrop) {
+            unbindBackdropEvents();
+        }
+
+        //  Remove active state hook class
+        dialog.classList.remove(activeClass);
+
+        // Remove backdrop if needed
+        if (DOM.backdrop) {
+            DOM.page.removeChild(DOM.backdrop);
+        }
+
+        // Reset state and return focus to button that opened the dialog
+        state.currentOpenButton.focus();
+        state.currentOpenButton = null;
+        state.currentDialog = null;
+    }
+
+
+    /**
+     * @function bindKeyCodeEvents
+     * @desc Adds event listener for keydown on the document
+     */
+    function bindKeyCodeEvents() {
+        document.addEventListener('keydown', handleKeyPress);
+    }
+
+
+    /**
+     * @function unbindKeyCodeEvents
+     * @desc Removes event listener for keydown on the document
+     */
+    function unbindKeyCodeEvents() {
+        document.removeEventListener('keydown', handleKeyPress);
+    }
+
+
     /**
      * @function handleKeyPress
      * @desc Checks to see if escape (key 27) has been pressed and dialog not modal
@@ -234,18 +250,6 @@ const UIDialog = ({
      */
     function handleKeyPress(e) {
         if (e.keyCode === keyCodes.ESCAPE && !isModal) {
-            hideDialog(state.currentDialog);
-        }
-    }
-
-
-    /**
-     * @function handleBackdropClick
-     * @desc If backdrop has been clicked, dismiss dialog
-     * @param {Event} e
-     */
-    function handleBackdropClick(e) {
-        if (e.target === DOM.backdrop) {
             hideDialog(state.currentDialog);
         }
     }
@@ -270,13 +274,13 @@ const UIDialog = ({
         }
 
         DOM.dialogs.forEach(dialog => {
-            // add accessibility to dialog
+            // Add accessibility to dialog
             addDialogA11y(dialog);
 
-            // set up event listeners for opening dialog
+            // Set up event listeners for opening dialog
             bindOpenEvents(dialog);
 
-            // set ready class
+            // Set ready class
             dialog.classList.add(readyClass);
         });
     }

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -42,7 +42,7 @@ const UIDialog = ({
         // Create the backdrop
         DOM.backdrop = document.createElement('div');
 
-        DOM.backdrop.classList.add(defaultClassNames.DIALOGBACKDROP);
+        DOM.backdrop.classList.add(defaultClassNames.DIALOG_BACKDROP);
 
         addBackdropA11y(DOM.backdrop);
     }

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -1,6 +1,8 @@
 import {keyCodes, defaultClassNames, focusableSelectors} from '../../constants';
-import qa from '../../utils/qa';
+
+import createEl from '../../utils/createEl';
 import defer from '../../utils/defer';
+import qa from '../../utils/qa';
 
 
 /**
@@ -70,9 +72,7 @@ const UIDialog = ({
      */
     function createBackdrop() {
         // Create the backdrop
-        DOM.backdrop = document.createElement('div');
-
-        DOM.backdrop.classList.add(defaultClassNames.DIALOG_BACKDROP);
+        DOM.backdrop = createEl({id: 'hawk', className: defaultClassNames.DIALOG_BACKDROP});
 
         addBackdropA11y(DOM.backdrop);
     }

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -36,7 +36,6 @@ const UIDialog = ({
 
     /**
      * @function createBackdrop
-     * @type private
      * @desc Creates the dialog backdrop
      */
     function createBackdrop() {
@@ -51,7 +50,6 @@ const UIDialog = ({
 
     /**
      * @function addDialogA11y
-     * @type private
      * @desc Applies relevant roles and attributes to the dialog
      * @param {node} dialog
      */
@@ -65,7 +63,6 @@ const UIDialog = ({
 
     /**
      * @function addBackdropA11y
-     * @type private
      * @desc Applies relevant roles and attributes to the backdrop
      * @param {node} backdrop
      */
@@ -75,7 +72,6 @@ const UIDialog = ({
 
     /**
      * @function closeDialog
-     * @type private
      * @desc sets up dialog ready to be hidden
      * @param {node} dialog
      */
@@ -85,7 +81,6 @@ const UIDialog = ({
 
     /**
      * @function hideDialog
-     * @type private
      * @desc adds aria attributes and hides dialog
      * @param {node} dialog
      */
@@ -118,7 +113,6 @@ const UIDialog = ({
 
     /**
      * @function openDialog
-     * @type private
      * @desc sets up dialog and state ready to be shown
      * @param {node} dialog
      */
@@ -138,7 +132,6 @@ const UIDialog = ({
 
     /**
      * @function bindOpenEvents
-     * @type private
      * @desc Finds all open buttons and attaches click event listener
      * @param {node} dialog
      */
@@ -154,7 +147,6 @@ const UIDialog = ({
 
     /**
      * @function bindCloseEvents
-     * @type private
      * @desc Finds all close buttons and attaches click event listener
      * @param {node} dialog
      */
@@ -168,7 +160,6 @@ const UIDialog = ({
 
     /**
      * @function bindKeyCodeEvents
-     * @type private
      * @desc Adds event listener for keydown on the document
      */
     function bindKeyCodeEvents() {
@@ -177,7 +168,6 @@ const UIDialog = ({
 
     /**
      * @function unbindKeyCodeEvents
-     * @type private
      * @desc Removes event listener for keydown on the document
      */
     function unbindKeyCodeEvents() {
@@ -186,7 +176,6 @@ const UIDialog = ({
 
     /**
      * @function bindBackdropEvents
-     * @type private
      * @desc Adds event listener for keydown on the document
      */
     function bindBackdropEvents() {
@@ -196,7 +185,6 @@ const UIDialog = ({
 
     /**
      * @function unbindBackdropEvents
-     * @type private
      * @desc Removes event listener for keydown on the document
      */
     function unbindBackdropEvents() {
@@ -206,7 +194,6 @@ const UIDialog = ({
 
     /**
      * @function showDialog
-     * @type private
      * @desc Sets up focusable elements, close and key events and displays modal
      */
     function showDialog(dialog) {

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -2,6 +2,7 @@ import {keyCodes, defaultClassNames, focusableSelectors} from '../../constants';
 import qa from '../../utils/qa';
 import defer from '../../utils/defer';
 
+
 /**
  * @function UIDialog
  * @version 0.0.2
@@ -94,9 +95,13 @@ const UIDialog = ({
         dialog.setAttribute('aria-hidden', true);
         dialog.removeAttribute('tabindex');
 
-        // TODO - Unbind events
+        // Unbind events
+        unbindKeyCodeEvents();
+        if (!isModal && DOM.backdrop) {
+            unbindBackdropEvents();
+        }
 
-        //  remove active state hook class
+        //  Remove active state hook class
         dialog.classList.remove(activeClass);
 
         // Remove backdrop if needed
@@ -104,7 +109,7 @@ const UIDialog = ({
             DOM.page.removeChild(DOM.backdrop);
         }
 
-        //  return focus to button that opened the dialog and reset state
+        //  Return focus to button that opened the dialog and reset state
         state.currentOpenButton.focus();
         state.currentOpenButton = null;
         state.currentDialog = null;
@@ -171,12 +176,31 @@ const UIDialog = ({
     }
 
     /**
+     * @function unbindKeyCodeEvents
+     * @type private
+     * @desc Removes event listener for keydown on the document
+     */
+    function unbindKeyCodeEvents() {
+        document.removeEventListener('keydown', handleKeyPress);
+    }
+
+    /**
      * @function bindBackdropEvents
      * @type private
      * @desc Adds event listener for keydown on the document
      */
     function bindBackdropEvents() {
         DOM.backdrop.addEventListener('click', handleBackdropClick);
+    }
+
+
+    /**
+     * @function unbindBackdropEvents
+     * @type private
+     * @desc Removes event listener for keydown on the document
+     */
+    function unbindBackdropEvents() {
+        DOM.backdrop.removeEventListener('click', handleBackdropClick);
     }
 
 
@@ -203,7 +227,9 @@ const UIDialog = ({
         //  Bind events
         defer(bindKeyCodeEvents);
         defer(bindCloseEvents);
-        if (!isModal && DOM.backdrop) defer(bindBackdropEvents);
+        if (!isModal && DOM.backdrop) {
+            defer(bindBackdropEvents);
+        }
 
         // Add backdrop if needed
         if (DOM.backdrop) {

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -6,16 +6,16 @@ import qa from '../../utils/qa';
 
 
 /**
- * @function UIDialog
+ * @function VUIDialog
  * @version 0.0.2
- * @desc Main UIDialog function. Creates instances of the dialog based on
+ * @desc Main VUIDialog function. Creates instances of the dialog based on
  * parameters passed in.
  * @param {object} settings
  */
-const UIDialog = ({
+const VUIDialog = ({
         dialog = '.js-dialog',
-        openBtn = '.js-dialog-btn',
-        closeBtn = '.js-dialog-close-btn',
+        openBtn = '.js-dialog-btn-open',
+        closeBtn = '.js-dialog-btn-close',
         isModal = false,
         isAlert = false,
         readyClass = defaultClassNames.IS_READY,
@@ -23,16 +23,16 @@ const UIDialog = ({
         showBackdrop = true
     } = {}) => {
 
-    // Stores all the dom nodes for the module
+    // Stores all the constant dom nodes for the component regardless of instance.
     let DOM = {
         dialogs: qa(dialog)
     };
 
-    // Keeps track of current state
+    // Keeps track of current instance of dialog.
     let state = {
         currentOpenButton: null,
         currentDialog: null,
-        focusableElements: null //  elements within modal
+        focusableElements: null
     };
 
 
@@ -72,19 +72,7 @@ const UIDialog = ({
      */
     function createBackdrop() {
         // Create the backdrop
-        DOM.backdrop = createEl({id: 'hawk', className: defaultClassNames.DIALOG_BACKDROP});
-
-        addBackdropA11y(DOM.backdrop);
-    }
-
-
-    /**
-     * @function addBackdropA11y
-     * @desc Applies relevant roles and attributes to the backdrop
-     * @param {node} backdrop
-     */
-    function addBackdropA11y(backdrop) {
-        backdrop.setAttribute('aria-hidden', true);
+        DOM.backdrop = createEl({className: defaultClassNames.BACKDROP});
     }
 
 
@@ -109,8 +97,8 @@ const UIDialog = ({
     function bindOpenEvents(dialog) {
         const id = dialog.getAttribute('id');
 
-        // Grab all buttons which open this instance of the modal
-        const openButtons = qa(`${openBtn}[aria-controls="${id}"]`);
+        // Grab all buttons which open this instance of the dialog
+        const openButtons = qa(`${openBtn}[data-controls-modal="${id}"]`);
 
         openButtons.forEach(button => button.addEventListener('click', openDialog));
     }
@@ -118,8 +106,8 @@ const UIDialog = ({
 
     /**
      * @function openDialog
-     * @desc sets up dialog and state ready to be shown
-     * @param {node} dialog
+     * @desc Sets up dialog and state ready to be shown.  Is triggered by user clicking on open button
+     * @param {Event} e
      */
     function openDialog(e) {
         // Get trigger button so focus can be returned to it later
@@ -137,17 +125,17 @@ const UIDialog = ({
 
     /**
      * @function showDialog
-     * @desc Sets up focusable elements, close and key events and displays modal
+     * @desc Sets up focusable elements, close and key events and displays dialog
      */
     function showDialog(dialog) {
-        //  Focus the modal and remove aria attributes
+        //  Focus the dialog and remove aria attributes
         dialog.setAttribute('tabindex', 1);
         dialog.setAttribute('aria-hidden', false);
 
-        //  Set the first and last focusable elements
+        //  Grabs elements that are focusable inside this dialog instance.
         state.focusableElements = qa(NATIVELY_FOCUSABLE_ELEMENTS.join(), dialog);
 
-        //  focus first element if exists, otherwise focus dialog element
+        //  Focus first element if exists, otherwise focus dialog element
         if (state.focusableElements.length) {
             state.focusableElements[0].focus();
         } else {
@@ -177,7 +165,7 @@ const UIDialog = ({
      * @param {node} dialog
      */
     function bindCloseEvents(dialog = state.currentDialog) {
-        // Grab all buttons which open this instance of the modal
+        // Grab all buttons which open this instance of the dialog
         const closeButtons = qa(closeBtn);
 
         closeButtons.forEach(button => button.addEventListener('click', closeDialog));
@@ -186,7 +174,7 @@ const UIDialog = ({
 
     /**
      * @function closeDialog
-     * @desc Sets up dialog ready to be hidden
+     * @desc Bridging function that sets up dialog ready to be hidden
      */
     function closeDialog() {
         hideDialog(state.currentDialog);
@@ -200,7 +188,7 @@ const UIDialog = ({
      */
     function hideDialog(dialog) {
 
-        //  show container and focus the dialog
+        //  Hide dialog for screenreaders and make untabbable
         dialog.setAttribute('aria-hidden', true);
         dialog.removeAttribute('tabindex');
 
@@ -245,11 +233,11 @@ const UIDialog = ({
 
     /**
      * @function handleKeyPress
-     * @desc Checks to see if escape (key 27) has been pressed and dialog not modal
+     * @desc Checks to see if escape (key 27) has been pressed and dialog not dialog
      * @param {Event} e
      */
     function handleKeyPress(e) {
-        if (e.keyCode === keyCodes.ESCAPE && !isModal) {
+        if (e.keyCode === keyCodes.ESCAPE && !isModal && !isAlert) {
             hideDialog(state.currentDialog);
         }
     }
@@ -285,9 +273,9 @@ const UIDialog = ({
         });
     }
 
-    // Initialise UIDialog module
+    // Initialise VUIDialog component
     init();
 };
 
 
-export default UIDialog;
+export default VUIDialog;

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -99,9 +99,15 @@ const UIDialog = ({
         //  remove active state hook class
         dialog.classList.remove(activeClass);
 
+        // Remove backdrop if needed
+        if (DOM.backdrop) {
+            DOM.page.removeChild(DOM.backdrop);
+        }
+
         //  return focus to button that opened the dialog and reset state
         state.currentOpenButton.focus();
         state.currentOpenButton = null;
+        state.currentDialog = null;
     }
 
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -110,7 +110,7 @@ const UIDialog = ({
         const id = dialog.getAttribute('id');
 
         // Grab all buttons which open this instance of the modal
-        let openButtons = qa(`${openBtn}[aria-controls="${id}"]`);
+        const openButtons = qa(`${openBtn}[aria-controls="${id}"]`);
 
         openButtons.forEach(button => button.addEventListener('click', openDialog));
     }
@@ -178,7 +178,7 @@ const UIDialog = ({
      */
     function bindCloseEvents(dialog = state.currentDialog) {
         // Grab all buttons which open this instance of the modal
-        let closeButtons = qa(closeBtn);
+        const closeButtons = qa(closeBtn);
 
         closeButtons.forEach(button => button.addEventListener('click', closeDialog));
     }

--- a/src/components/dialog/index.js
+++ b/src/components/dialog/index.js
@@ -1,0 +1,3 @@
+import VUIDialog from './dialog';
+
+export default VUIDialog;

--- a/src/constants.js
+++ b/src/constants.js
@@ -16,7 +16,7 @@ export const defaultClassNames = {
     IS_HIDDEN: 'is-hidden',
     IS_READY: 'is-ready',
     NO_BACKDROP: 'no-backdrop',
-    DIALOG_BACKDROP: 'dialog-backdrop'
+    BACKDROP: 'dialog-backdrop'
 };
 
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,7 +12,12 @@ export const keyCodes = {
 
 // Classnames likely to be shared across modules
 export const defaultClassNames = {
+    IS_ACTIVE: 'is-active',
     IS_HIDDEN: 'is-hidden',
+    IS_READY: 'is-ready',
     NO_BACKDROP: 'no-backdrop',
     DIALOG_BACKDROP: 'dialog-backdrop'
 };
+
+
+export const focusableSelectors = ['a[href]', 'area[href]', 'input:not([disabled])', 'select:not([disabled])', 'textarea:not([disabled])', 'button:not([disabled])', 'iframe', 'object', 'embed', '[contenteditable]', '[tabindex]:not([tabindex^="-"])'];

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,4 +20,16 @@ export const defaultClassNames = {
 };
 
 
-export const focusableSelectors = ['a[href]', 'area[href]', 'input:not([disabled])', 'select:not([disabled])', 'textarea:not([disabled])', 'button:not([disabled])', 'iframe', 'object', 'embed', '[contenteditable]', '[tabindex]:not([tabindex^="-"])'];
+export const NATIVELY_FOCUSABLE_ELEMENTS = [
+    'a[href]',
+    'area[href]',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    'button:not([disabled])',
+    'iframe',
+    'object',
+    'embed',
+    '[contenteditable]',
+    '[tabindex]:not([tabindex^="-"])'
+];

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import UIDialog from './components/dialog/dialog';
 
-let dialog1 = UIDialog();
-let dialog2 = UIDialog({
+const dialog1 = UIDialog();
+const dialog2 = UIDialog({
     dialog:         '.js-dialog-2',
     openBtn:        '.js-dialog-btn-2',
     closeBtn:       '.js-dialog-close-btn-2',

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-import UIDialog from './components/dialog/dialog';
+import VUIDialog from './components/dialog/';
 
-const dialog1 = UIDialog();
-const dialog2 = UIDialog({
+const dialog1 = VUIDialog();
+const dialog2 = VUIDialog({
     dialog:         '.js-dialog-2',
-    openBtn:        '.js-dialog-btn-2',
-    closeBtn:       '.js-dialog-close-btn-2',
+    openBtn:        '.js-dialog-btn-open-2',
+    closeBtn:       '.js-dialog-btn-close-2',
     isModal:        true,
     showBackdrop:   false
 });

--- a/src/utils/createEl/createEl.js
+++ b/src/utils/createEl/createEl.js
@@ -1,0 +1,35 @@
+/**
+ * @function createEl
+ * @desc creates an element from an object
+ * @param {obj} attributes for element
+ * @param {string} element the type of element to create
+ * @param {string} className a list of classes to be applied
+ * @param {rest} attributes any other attributes passed in.  Must be provided in camelcase
+ */
+
+const createEl = ({
+        element = 'div',
+        className,
+        ...attributes
+    } = {}) => {
+
+    // Setup base element
+    let el = document.createElement(element);
+
+    // adds classes
+    if (className) {
+        el.classList.add(className);
+    }
+
+    // Adds other attributes e.g id, type, role etc provided
+    if (attributes !== {}) {
+        for (let key in attributes) {
+            el.setAttribute(key, attributes[key]);
+        }
+    }
+
+    return el;
+};
+
+
+export default createEl;

--- a/src/utils/createEl/createEl.js
+++ b/src/utils/createEl/createEl.js
@@ -1,10 +1,11 @@
 /**
  * @function createEl
  * @desc creates an element from an object
- * @param {obj} attributes for element
+ * @param {object} attributes for element
  * @param {string} element the type of element to create
  * @param {string} className a list of classes to be applied
- * @param {rest} attributes any other attributes passed in.  Must be provided in camelcase
+ * @param {object} attributes any other attributes passed in.  Must be provided in camelcase
+ * @return {node} - Element with all applied attributes.
  */
 
 const createEl = ({

--- a/src/utils/createEl/createEl.js
+++ b/src/utils/createEl/createEl.js
@@ -7,11 +7,10 @@
  * @param {object} attributes any other attributes passed in.  Must be provided in camelcase
  * @return {node} - Element with all applied attributes.
  */
-
 const createEl = ({
-        element = 'div',
-        className,
-        ...attributes
+    element = 'div',
+    className,
+    ...attributes
     } = {}) => {
 
     // Setup base element

--- a/src/utils/createEl/index.js
+++ b/src/utils/createEl/index.js
@@ -1,0 +1,3 @@
+import createEl from './createEl';
+
+export default createEl;

--- a/src/utils/defer/defer.js
+++ b/src/utils/defer/defer.js
@@ -1,0 +1,10 @@
+/**
+ * @function defer
+ * @desc Prevents function triggering until completion
+ * @param {function} func function to run
+ */
+const defer = func => {
+    if (typeof func === 'function') setTimeout(func, 0);
+};
+
+export default defer;

--- a/src/utils/defer/index.js
+++ b/src/utils/defer/index.js
@@ -1,0 +1,3 @@
+import defer from './defer';
+
+export default defer;

--- a/src/utils/qa/index.js
+++ b/src/utils/qa/index.js
@@ -1,0 +1,3 @@
+import qa from './qa';
+
+export default qa;

--- a/src/utils/qa/qa.js
+++ b/src/utils/qa/qa.js
@@ -1,5 +1,11 @@
 const doc = document;
 
+/**
+ * @function qa
+ * @desc query selector all with results as array
+ * @param {string} [el] element to search for
+ * @param {node} context element or document to search inside of
+ */
 const qa = (el, context = doc) => [].slice.call(context.querySelectorAll(el));
 
 export default qa;

--- a/src/utils/qa/qa.js
+++ b/src/utils/qa/qa.js
@@ -1,0 +1,5 @@
+const doc = document;
+
+const qa = (el, context = doc) => [].slice.call(context.querySelectorAll(el));
+
+export default qa;

--- a/src/utils/qa/qa.js
+++ b/src/utils/qa/qa.js
@@ -5,6 +5,7 @@ const doc = document;
  * @desc query selector all with results as array
  * @param {string} [el] element to search for
  * @param {node} context element or document to search inside of
+ * @return {array} - Elements that matched query.
  */
 const qa = (el, context = doc) => [].slice.call(context.querySelectorAll(el));
 


### PR DESCRIPTION
This is a big of a biggie.  Main changes are
- Added docblock style comments to all functions
- Added utils for querySelectorAll and defer
- Added `aria-controls` and `id` properties to html elements which are used to identify which modal to open
- Now attaches event listeners to all instances with the same js hook rather than just the first found
- Some really basic a11y
- Return focus to launch button after close

There are still a few bugs, but I didn't want to get too far into it

![modal](https://cloud.githubusercontent.com/assets/1312905/17764633/6955519e-6518-11e6-94e5-7cfb1f5410b5.gif)
