### PR TITLE
Focus trap utility

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -20,6 +20,8 @@
     <div id="my-dialog" class="dialog js-dialog">
         <h3>Hello!</h3>
         <p>I am dialog 1 content. I can be closed with both escape and buttons.</p>
+        <a href="">Tester Link</a>
+        <a href="">My Link</a>
         <button class="js-dialog-close-btn">Close dialog 1</button>
     </div>
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -3,6 +3,7 @@ import {keyCodes, defaultClassNames, NATIVELY_FOCUSABLE_ELEMENTS} from '../../co
 import createEl from '../../utils/createEl';
 import defer from '../../utils/defer';
 import qa from '../../utils/qa';
+import trapFocus from '../../utils/trapFocus';
 
 
 /**
@@ -141,14 +142,16 @@ const UIDialog = ({
      */
     function showDialog(dialog) {
         //  Focus the modal and remove aria attributes
-        dialog.setAttribute('tabindex', 1);
+        dialog.setAttribute('tabindex', 0);
         dialog.setAttribute('aria-hidden', false);
 
-        //  Set the first and last focusable elements
+        //  Get focusable elements from inside Dialog
         state.focusableElements = qa(NATIVELY_FOCUSABLE_ELEMENTS.join(), dialog);
 
-        //  focus first element if exists, otherwise focus dialog element
+        //  Set focus to first element, fallback to Dialog.
         if (state.focusableElements.length) {
+            // TODO - figure out why this isn't focussing.
+            // console.log('found focusable element', state.focusableElements[0]);
             state.focusableElements[0].focus();
         } else {
             dialog.focus();
@@ -251,6 +254,10 @@ const UIDialog = ({
     function handleKeyPress(e) {
         if (e.keyCode === keyCodes.ESCAPE && !isModal) {
             hideDialog(state.currentDialog);
+        }
+
+        if (e.keyCode === keyCodes.TAB && !isModal) {
+            trapFocus(e, state.focusableElements);
         }
     }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,8 @@
 // Keyboard keycodes
 export const keyCodes = {
-    ESCAPE: 27,
+    TAB: 9,
     ENTER: 13,
+    ESCAPE: 27,
     SPACE: 32,
     LEFT_ARROW: 37,
     UP_ARROW: 38,

--- a/src/utils/trapFocus/index.js
+++ b/src/utils/trapFocus/index.js
@@ -1,0 +1,3 @@
+import trapFocus from './trapFocus';
+
+export default trapFocus;

--- a/src/utils/trapFocus/trapFocus.js
+++ b/src/utils/trapFocus/trapFocus.js
@@ -1,0 +1,24 @@
+/**
+ * @function trapFocus
+ * @desc Traps focus within an element
+ * @param {Event} e
+ * @param {array} focusableElements array of nodes that can be focussed
+ */
+const trapFocus = (e, focusableElements) => {
+
+    const currentFocusIndex = focusableElements.indexOf(document.activeElement);
+
+    // If shift held and first element active focus last element
+    if (e.shiftKey && currentFocusIndex === 0) {
+        focusableElements[focusableElements.length - 1].focus();
+        e.preventDefault();
+
+    // If shift not held and last element active focus first element
+    } else if (!e.shiftKey && currentFocusIndex === focusableElements.length - 1) {
+        focusableElements[0].focus();
+        e.preventDefault();
+    }
+};
+
+
+export default trapFocus;


### PR DESCRIPTION
There is a bug with the underlaying modal (unrelated to the focus trap) where the focus doesn't immediately jump into the modal.  But the focus trap util itself does work once inside:

This PR is pointing at the `ui-modal` branch so can't be merged in until that is.  Review still welcome though :)

![focus trap](https://cloud.githubusercontent.com/assets/1312905/17855875/c916021a-6872-11e6-86b9-f71332fa1409.gif)
