### PR TITLE
23 > auto focus in dialog

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -9,9 +9,9 @@
 
     <div class="main-content">
         <h1>Vanilla UI—Dialog</h1>
-        <button class="js-dialog-btn-open" type="button" data-controls-modal="my-dialog">Open dialog 1</button>
-        <button class="js-dialog-btn-open" type="button" data-controls-modal="my-dialog2">Open dialog 2</button>
-        <button class="js-dialog-btn-open-2" type="button" data-controls-modal="another-dialog">Open dialog 2</button>
+        <button class="js-dialog-btn-open" type="button" data-controls-dialog="my-dialog">Open dialog 1</button>
+        <button class="js-dialog-btn-open" type="button" data-controls-dialog="my-dialog2">Open dialog 2</button>
+        <button class="js-dialog-btn-open-2" type="button" data-controls-dialog="another-dialog">Open dialog 2</button>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,6 +10,7 @@
     <div class="main-content">
         <h1>Vanilla UI—Dialog</h1>
         <button class="js-dialog-btn-open" type="button" data-controls-modal="my-dialog">Open dialog 1</button>
+        <button class="js-dialog-btn-open" type="button" data-controls-modal="my-dialog2">Open dialog 2</button>
         <button class="js-dialog-btn-open-2" type="button" data-controls-modal="another-dialog">Open dialog 2</button>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Officia inventore illum dignissimos quidem, porro odio quo eaque suscipit velit reprehenderit, possimus earum magnam voluptates ipsum necessitatibus cupiditate. Exercitationem eaque, quisquam.</p>
@@ -23,6 +24,11 @@
         <a href="">Tester Link</a>
         <a href="">My Link</a>
         <button class="js-dialog-btn-close">Close dialog 1</button>
+    </div>
+
+    <div id="my-dialog2" class="dialog js-dialog">
+        <h3>Hello!</h3>
+        <p>I am dialog 1 content. I can be closed with both escape and buttons.</p>
     </div>
 
     <div id="another-dialog" class="dialog js-dialog-2">

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -103,7 +103,7 @@ const VUIDialog = ({
         // Get dialog that should be opened
         const dialog = document.getElementById(button.getAttribute('data-controls-dialog'));
 
-        //  Update State
+        // Update State
         state.currentOpenButton = button;
         state.currentDialog = dialog;
 
@@ -116,11 +116,11 @@ const VUIDialog = ({
      * @desc Sets up focusable elements, close and key events and displays dialog
      */
     function showDialog(dialog) {
-        //  Focus the dialog and remove aria attributes
+        // Focus the dialog and remove aria attributes
         dialog.setAttribute('tabindex', 1);
         dialog.setAttribute('aria-hidden', false);
 
-        //  Bind events
+        // Bind events
         defer(bindKeyCodeEvents);
         defer(bindCloseEvents);
         if (!isModal && DOM.backdrop) {
@@ -132,13 +132,13 @@ const VUIDialog = ({
             DOM.page.appendChild(DOM.backdrop);
         }
 
-        //  Grabs elements that are focusable inside this dialog instance.
+        // Grabs elements that are focusable inside this dialog instance.
         state.focusableElements = qa(NATIVELY_FOCUSABLE_ELEMENTS.join(), dialog);
 
-        //  Add class to make dialog visible. Needs to occur before focus.
+        // Add class to make dialog visible. Needs to occur before focus.
         dialog.classList.add(activeClass);
 
-        //  Set focus to first element, fallback to Dialog.
+        // Set focus to first element, fallback to Dialog.
         if (state.focusableElements.length) {
             state.focusableElements[0].focus();
         } else {
@@ -176,7 +176,7 @@ const VUIDialog = ({
      */
     function hideDialog(dialog) {
 
-        //  Hide dialog for screenreaders and make untabbable
+        // Hide dialog for screenreaders and make untabbable
         dialog.setAttribute('aria-hidden', true);
         dialog.removeAttribute('tabindex');
 
@@ -186,7 +186,7 @@ const VUIDialog = ({
             unbindBackdropEvents();
         }
 
-        //  Remove active state hook class
+        // Remove active state hook class
         dialog.classList.remove(activeClass);
 
         // Remove backdrop if needed

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -120,16 +120,6 @@ const VUIDialog = ({
         dialog.setAttribute('tabindex', 1);
         dialog.setAttribute('aria-hidden', false);
 
-        //  Grabs elements that are focusable inside this dialog instance.
-        state.focusableElements = qa(NATIVELY_FOCUSABLE_ELEMENTS.join(), dialog);
-
-        //  Set focus to first element, fallback to Dialog.
-        if (state.focusableElements.length) {
-            state.focusableElements[0].focus();
-        } else {
-            dialog.focus();
-        }
-
         //  Bind events
         defer(bindKeyCodeEvents);
         defer(bindCloseEvents);
@@ -142,8 +132,18 @@ const VUIDialog = ({
             DOM.page.appendChild(DOM.backdrop);
         }
 
-        //  Add class to make dialog visible
+        //  Grabs elements that are focusable inside this dialog instance.
+        state.focusableElements = qa(NATIVELY_FOCUSABLE_ELEMENTS.join(), dialog);
+
+        //  Add class to make dialog visible. Needs to occur before focus.
         dialog.classList.add(activeClass);
+
+        //  Set focus to first element, fallback to Dialog.
+        if (state.focusableElements.length) {
+            state.focusableElements[0].focus();
+        } else {
+            dialog.focus();
+        }
     }
 
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -86,7 +86,7 @@ const VUIDialog = ({
         const id = dialog.getAttribute('id');
 
         // Grab all buttons which open this instance of the dialog
-        const openButtons = qa(`${openBtn}[data-controls-modal="${id}"]`);
+        const openButtons = qa(`${openBtn}[data-controls-dialog="${id}"]`);
 
         openButtons.forEach(button => button.addEventListener('click', openDialog));
     }
@@ -101,7 +101,7 @@ const VUIDialog = ({
         // Get trigger button so focus can be returned to it later
         const button = e.target;
         // Get dialog that should be opened
-        const dialog = document.getElementById(button.getAttribute('data-controls-modal'));
+        const dialog = document.getElementById(button.getAttribute('data-controls-dialog'));
 
         //  Update State
         state.currentOpenButton = button;


### PR DESCRIPTION
Fixes: https://github.com/fedordead/vanilla-ui/issues/23
Expected behaviour:

If focusable element inside dialog focus should switch to the first one on open.

If no focusable elements the dialog itself should be focused
![autofocus](https://cloud.githubusercontent.com/assets/1312905/18027139/52e5e026-6c53-11e6-95a6-3d92e2e79770.gif)
