### PR TITLE
20 - Close button

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -22,7 +22,9 @@ const VUIDialog = ({
         readyClass = DEFAULT_CLASSNAMES.isReady,
         activeClass = DEFAULT_CLASSNAMES.isActive,
         showBackdrop = true,
-        hasCloseBtn = false
+        hasCloseBtn = false,
+        closeButtonClassName = 'c-dialog__btn-close',
+        closeButtonText = 'Close dialog'
     } = {}) => {
 
     // Stores all the constant dom nodes for the component regardless of instance.
@@ -115,13 +117,17 @@ const VUIDialog = ({
         dialog.setAttribute('tabindex', 1);
         dialog.setAttribute('aria-hidden', false);
 
-        // Alerts don't have close buttons
-        if (hasCloseBtn && !isAlert) {
+        // Alerts and modal dialog types don't have close buttons
+        if (hasCloseBtn && !isAlert && !isModal) {
             const closeBtnEl = createEl({
                 element: 'button',
-                className: 'js-dialog-btn-close',
-                type: 'button'
-            })
+                className: ['js-dialog-btn-close', closeButtonClassName],
+                type: 'button',
+                children: [{
+                    element: 'span',
+                    text: closeButtonText
+                }]
+            });
             dialog.appendChild(closeBtnEl);
         }
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -21,7 +21,8 @@ const VUIDialog = ({
         isAlert = false,
         readyClass = DEFAULT_CLASSNAMES.isReady,
         activeClass = DEFAULT_CLASSNAMES.isActive,
-        showBackdrop = true
+        showBackdrop = true,
+        hasCloseBtn = false
     } = {}) => {
 
     // Stores all the constant dom nodes for the component regardless of instance.
@@ -113,6 +114,16 @@ const VUIDialog = ({
         // Focus the dialog and remove aria attributes
         dialog.setAttribute('tabindex', 1);
         dialog.setAttribute('aria-hidden', false);
+
+        // Alerts don't have close buttons
+        if (hasCloseBtn && !isAlert) {
+            const closeBtnEl = createEl({
+                element: 'button',
+                className: 'js-dialog-btn-close',
+                type: 'button'
+            })
+            dialog.appendChild(closeBtnEl);
+        }
 
         // Bind events
         defer(bindKeyCodeEvents);


### PR DESCRIPTION
- Option to include close button
- if this is true and it's not an alert or modal dialog a close button is appended to the DOM

NB: for the `children` and `className` properties of `createEl()` to work this relies on the complete function laid out in PR https://github.com/fedordead/vanilla-ui/pull/35 to be merged in.
